### PR TITLE
Openwrt 21.02 pr更新 2021.7.11

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -437,6 +437,16 @@ return view.extend({
 		o.placeholder = '/tmp';
 		o.rmempty = true;
 
+		o = s.taboption('adv_dns', form.ListValue, 'adb_dnsinstance', _('DNS Instance'), _('Set the dns backend instance used by adblock.'));
+		o.value('0', _('First instance (default)'));
+		o.value('1', _('Second instance'));
+		o.value('2', _('Third instance'));
+		o.value('3', _('Fourth instance'));
+		o.value('4', _('Fifth instance'));
+		o.depends('adb_dns', 'dnsmasq');
+		o.optional = true;
+		o.rmempty = true;
+
 		o = s.taboption('adv_dns', form.Value, 'adb_dnstimeout', _('DNS Restart Timeout'), _('Timeout to wait for a successful DNS backend restart.'));
 		o.placeholder = '20';
 		o.datatype = 'range(1,60)';

--- a/applications/luci-app-adblock/po/ar/adblock.po
+++ b/applications/luci-app-adblock/po/ar/adblock.po
@@ -44,7 +44,7 @@ msgstr "أضف هذا النطاق (الفرعي) لقائمتك السوداء 
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "أضف هذا النطاق (الفرعي) لقائمتك المسموحة المحلية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "قائمة حظر إضافية"
 
@@ -68,11 +68,11 @@ msgstr "إعدادات متقدمة للبريد الالكتروني"
 msgid "Advanced Report Settings"
 msgstr "إعدادات متقدمة للتقارير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "القائمة السوداء..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -148,7 +148,7 @@ msgstr "استعلام لقائمة الحظر..."
 msgid "Blocklist Sources"
 msgstr "مصادر قائمة الحظر"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -166,8 +166,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "فئات"
 
@@ -214,13 +214,17 @@ msgstr "DNS الخلفية"
 msgid "DNS Directory"
 msgstr "دليل DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "تقرير DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "مهلة إعادة تشغيل DNS"
 
@@ -228,15 +232,15 @@ msgstr "مهلة إعادة تشغيل DNS"
 msgid "Date"
 msgstr "تاريخ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "تعطيل السماح DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "تعطيل إعادة بدء DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -244,7 +248,7 @@ msgstr ""
 "قم بتعطيل عمليات إعادة تشغيل adblock التي تم تشغيلها لخلفيات DNS مع وظائف "
 "التحميل التلقائي / inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -280,11 +284,11 @@ msgstr "تحميل الأداة"
 msgid "E-Mail Notification"
 msgstr "إعلام البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "عدد إعلام البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "ملف تعريف البريد الإلكتروني"
 
@@ -292,11 +296,11 @@ msgstr "ملف تعريف البريد الإلكتروني"
 msgid "E-Mail Receiver Address"
 msgstr "عنوان مستقبل البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "عنوان مرسل البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "موضوع البريد الإلكتروني"
 
@@ -345,17 +349,21 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "الوظائف الحالية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "مجال بحث DNS خارجي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "المجال الخارجي للتحقق من إعادة تشغيل DNS الخلفية بنجاح. يرجى ملاحظة: لتعطيل "
 "هذا الاختيار ، قم بتعيين هذا الخيار على \"خطأ\"."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -369,11 +377,15 @@ msgstr "منافذ جدار الحماية التي يجب فرضها محليً
 msgid "Firewall source zones that should be forced locally."
 msgstr "مناطق مصدر جدار الحماية التي يجب فرضها محليًا."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "مسح ذاكرة التخزين المؤقت DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "امسح ذاكرة التخزين المؤقت ل DNS قبل معالجة adblock أيضًا."
 
@@ -388,6 +400,10 @@ msgstr "البوابات القسرية"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "مناطق قسرية"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -411,7 +427,7 @@ msgstr "منح حق الوصول إلى Adblock لتطبيق LuCI"
 msgid "Information"
 msgstr "معلومة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "دليل السجن"
 
@@ -435,7 +451,7 @@ msgstr "قصر البحث الآمن على مقدمي خدمات معينين."
 msgid "Line number to remove"
 msgstr "رقم الخط المراد إزالته"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "قائمة بأجهزة الشبكة المتاحة التي يستخدمها برنامج tcpdump."
 
@@ -487,7 +503,7 @@ msgstr "لا توجد سجلات ذات صلة ب adblock حتى الآن!"
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "الملف الشخصي المستخدم من قبل \"msmtp\" لرسائل البريد الإلكتروني الخاصة "
@@ -501,7 +517,7 @@ msgstr "استعلام"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "الاستعلام عن قوائم الحظر والنسخ الاحتياطية النشطة لمجال معين."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -562,39 +578,39 @@ msgstr "إعادة تحميل"
 msgid "Remove an existing job"
 msgstr "إزالة وظيفة موجودة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "تقرير عدد القطع"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "تقرير حجم القطعة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "دليل التقارير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "واجهة التقرير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "تقرير المنافذ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "الإبلاغ عن عدد القطع المستخدم بواسطة tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "الإبلاغ عن حجم القطعة المستخدم بواسطة tcpdump بالميجابايت."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -628,6 +644,10 @@ msgstr "تشغيل الأدوات"
 msgid "Save"
 msgstr "إحفض"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -636,13 +656,17 @@ msgstr ""
 "إرسال رسائل البريد الإلكتروني الخاصة بالإشعار عن حظر الإعلانات. يرجى ملاحظة: "
 "هذا يحتاج إلى تثبيت حزمة 'msmtp' إضافية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "عنوان المرسل لرسائل البريد الإلكتروني الخاصة بإشعار حظر الإعلانات."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "تعيين وظيفة adblock جديدة"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -656,11 +680,11 @@ msgstr ""
 "حجم قائمة انتظار التنزيل لمعالجة التنزيل (بما في ذلك الفرز والدمج وما إلى "
 "ذلك) بالتوازي."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "المصادر (الحجم والتركيز)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "قائمة منافذ مفصولة بمسافة يستخدمها tcpdump."
 
@@ -680,7 +704,7 @@ msgstr "الحالة / الإصدار"
 msgid "Suspend"
 msgstr "تعليق"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "الدليل الهدف لملفات التقارير المتعلقة ب DNS."
 
@@ -692,7 +716,7 @@ msgstr "الدليل الهدف للنسخ الاحتياطية لقائمة ا�
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "الدليل المستهدف لقائمة الحظر التي تم إنشاؤها \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "الدليل المستهدف لقائمة منع السجن التي تم إنشاؤها \"adb_list.jail\"."
 
@@ -722,6 +746,10 @@ msgstr "جزء الدقائق (اختياري ، النطاق: 0-59)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js:28
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "ناتج سجل النظام ، تمت تصفيته مسبقًا للرسائل ذات الصلة بحظر الإعلان فقط."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -755,7 +783,7 @@ msgstr ""
 msgid "Time"
 msgstr "وقت"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "حان الوقت لانتظار إعادة تشغيل خلفية DNS ناجحة."
 
@@ -771,7 +799,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "أفضل 10 إحصائيات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "موضوع رسائل البريد الإلكتروني الخاصة بإشعار adblock."
 
@@ -788,8 +816,8 @@ msgstr "تأخير الزناد"
 msgid "Unable to save changes: %s"
 msgstr "تعذر حفظ التغييرات: s%"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "المتغيرات"
 

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмени"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -69,11 +69,11 @@ msgstr "Paràmetres de correu avançats"
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Llista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -160,8 +160,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel•lar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Categories"
 
@@ -202,13 +202,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -216,21 +220,21 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -266,11 +270,11 @@ msgstr "Utilitat de baixades"
 msgid "E-Mail Notification"
 msgstr "Notificació de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -278,11 +282,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr "Adreça del destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -330,14 +334,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -352,11 +360,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -370,6 +382,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -391,7 +407,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -415,7 +431,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -463,7 +479,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -475,7 +491,7 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -530,39 +546,39 @@ msgstr "Torna a carregar"
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -596,18 +612,26 @@ msgstr ""
 msgid "Save"
 msgstr "Desar"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -620,11 +644,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -644,7 +668,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -656,7 +680,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -686,6 +710,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -710,7 +738,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -724,7 +752,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -741,8 +769,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -43,7 +43,7 @@ msgstr "Přidejte tuto (sub)doménu na místní blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Přidat tuto (sub)doménu na místní whitelist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -68,11 +68,11 @@ msgstr "Pokročilá nastavení e-mailu"
 msgid "Advanced Report Settings"
 msgstr "Pokročilá nastavení hlášení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -148,7 +148,7 @@ msgstr "Dotaz na blokovací seznam..."
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Storno"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -207,13 +207,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -221,21 +225,21 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -271,11 +275,11 @@ msgstr "Nástroj pro stahování"
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Počet e-mailových oznámení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-mailový profil"
 
@@ -283,11 +287,11 @@ msgstr "E-mailový profil"
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Adresa odesílatele e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Téma e-mailu"
 
@@ -335,17 +339,21 @@ msgstr "Vynutit SafeSearch pro Google, Bing, DuckDuckGo, Yandex a Pixabay."
 msgid "Existing job(s)"
 msgstr "Stávající úlohy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "Externí doména pro ověření úspěšného restartováni DNS backendu. Pro vypnutí "
 "tohoto ověření prosím vyberte možnost \"false\"."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -359,11 +367,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vyprázdnit mezipaměť DNS před zpracováním adblocku."
 
@@ -378,6 +390,10 @@ msgstr "Vynucené porty"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Vynucené zóny"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -398,7 +414,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informace"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -422,7 +438,7 @@ msgstr "Omezit SafeSearch na vybrané poskytovatele."
 msgid "Line number to remove"
 msgstr "Číslo řádku k odstranění"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Seznam dostupných síťových zařízení pro tcpdump."
 
@@ -476,7 +492,7 @@ msgstr "Zatím nejsou k dispozici žádné protokolové záznamy ohledně adbloc
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil \"msmtp\" pro e-mailové oznámení adblocku."
 
@@ -488,7 +504,7 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -545,39 +561,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -611,18 +627,26 @@ msgstr ""
 msgid "Save"
 msgstr "Uložit"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -635,11 +659,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -659,7 +683,7 @@ msgstr ""
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -671,7 +695,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -701,6 +725,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "Předfiltrovaný výstup syslog pouze se záznamy souvisejícími s adblock."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -725,7 +753,7 @@ msgstr ""
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -739,7 +767,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -756,8 +784,8 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -43,7 +43,7 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
@@ -69,11 +69,11 @@ msgstr "Fortgeschrittene E-Mail Einstellungen"
 msgid "Advanced Report Settings"
 msgstr "Fortgeschrittene Berichtseinstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Blockierliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -149,7 +149,7 @@ msgstr "Sperrlisten abfragen..."
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Kategorien"
 
@@ -215,13 +215,17 @@ msgstr "DNS-Backend"
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-Report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
@@ -229,15 +233,15 @@ msgstr "DNS-Restart-Timeout"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "DNS-Neustarts deaktivieren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -245,7 +249,7 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -281,11 +285,11 @@ msgstr "Download-Werkzeug"
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "E-Mail Benachrichtigungszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
@@ -293,11 +297,11 @@ msgstr "E-Mail-Profil"
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -346,17 +350,21 @@ msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS Lookup Domain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "Externe Beispiel-Domain um einen erfolgreichen Neustart des DNS-Backend zu "
 "prüfen. Auf \"false\" setzen, um dies zu deaktivieren."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -370,11 +378,15 @@ msgstr "Firewall-Ports, die lokal erzwungen/aufgelöst werden sollen."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Firewall-Zonen, die lokal erzwungen/aufgelöst werden sollen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
@@ -389,6 +401,10 @@ msgstr "Erzwungene Ports"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Erzwungene Zonen"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -412,7 +428,7 @@ msgstr "Zugriff auf adblock LuCI app erlauten"
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Sperrverzeichnis"
 
@@ -436,7 +452,7 @@ msgstr "SafeSearch auf bestimmte Anbieter einschränken."
 msgid "Line number to remove"
 msgstr "Zu entfernende Zeile"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
@@ -493,7 +509,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -506,7 +522,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -568,39 +584,39 @@ msgstr "Neu laden"
 msgid "Remove an existing job"
 msgstr "Entferne einen vorhandenen Job"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Report-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -634,6 +650,10 @@ msgstr "Run-Werkzeuge"
 msgid "Save"
 msgstr "Speichern"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -642,13 +662,17 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Setze einen neuen adblock Job"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -662,11 +686,11 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
@@ -686,7 +710,7 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "Zielverzeichnis für DNS-bezogene Report Dateien."
 
@@ -698,7 +722,7 @@ msgstr "Zielverzeichnis für Backups von Blocklisten."
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
@@ -727,6 +751,10 @@ msgstr "Der Minutenteil (Werte zw. 0-59)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js:28
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "Die Syslog-Ausgabe, vorgefiltert nur für Adblock-bezogene Nachrichten."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -762,7 +790,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -778,7 +806,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
@@ -795,8 +823,8 @@ msgstr "Verzögerung der Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Varianten"
 

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr "Προηγμένες ρυθμίσεις ηλεκτρονικού ταχ�
 msgid "Advanced Report Settings"
 msgstr "Σύνθετες ρυθμίσεις αναφοράς"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -46,7 +46,7 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
@@ -72,11 +72,11 @@ msgstr "Configuración avanzada de correo electrónico"
 msgid "Advanced Report Settings"
 msgstr "Configuración avanzada de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Permitir direcciones IP de clientes locales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 #, fuzzy
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
@@ -120,11 +120,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Bloquear direcciones IP de clientes locales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 #, fuzzy
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
@@ -160,7 +160,7 @@ msgstr "Consulta de lista de bloqueo..."
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -179,8 +179,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Categorías"
 
@@ -227,13 +227,17 @@ msgstr "Backend de DNS"
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Informe DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
@@ -241,15 +245,15 @@ msgstr "Tiempo de espera de reinicio de DNS"
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -257,7 +261,7 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desactivar la lista blanca selectiva de DNS (RPZ-PASSTHRU)."
 
@@ -293,11 +297,11 @@ msgstr "Utilidad de descarga"
 msgid "E-Mail Notification"
 msgstr "Notificación por correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
@@ -305,11 +309,11 @@ msgstr "Perfil de correo electrónico"
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -361,11 +365,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -373,6 +377,10 @@ msgstr ""
 "Dominio externo para verificar si un reinicio del servidor DNS ha sido "
 "exitoso. Tenga en cuenta: para desactivar esta comprobación, configure esta "
 "opción en 'falso'."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -386,11 +394,15 @@ msgstr "Puertos del cortafuegos que deben forzarse localmente."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origen del cortafuegos que deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
@@ -405,6 +417,10 @@ msgstr "Puertos forzados"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas forzadas"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -429,7 +445,7 @@ msgstr "Conceder acceso a la aplicación adblock de LuCI"
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
@@ -453,7 +469,7 @@ msgstr "Limitar SafeSearch a proveedores specíficos."
 msgid "Line number to remove"
 msgstr "Número de línea para eliminar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
@@ -507,7 +523,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Vista general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -521,7 +537,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -583,39 +599,39 @@ msgstr "Recargar"
 msgid "Remove an existing job"
 msgstr "Eliminar un trabajo existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -649,6 +665,10 @@ msgstr "Ejecutar utilidades"
 msgid "Save"
 msgstr "Guardar"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -657,7 +677,7 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
@@ -666,6 +686,10 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Establecer un nuevo trabajo de adblock"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -679,11 +703,11 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
@@ -703,7 +727,7 @@ msgstr "Estado/Versión"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "Directorio de destino para archivos de informes relacionados con DNS."
 
@@ -716,7 +740,7 @@ msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
@@ -749,6 +773,10 @@ msgstr "La porción de minutos (opcional, rango: 0-59)"
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "La salida de syslog, prefiltrada solo para mensajes relacionados con adblock."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -784,7 +812,7 @@ msgstr ""
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -800,7 +828,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
@@ -817,8 +845,8 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pudo guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Variantes"
 

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -43,7 +43,7 @@ msgstr "Lisää tämä (ali-)verkkonimi kieltolistallesi."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lisää tämä (ali-)verkkonimi sallittujen listallesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -68,11 +68,11 @@ msgstr "Sähköpostin lisäasetukset"
 msgid "Advanced Report Settings"
 msgstr "Raportoinnin lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Kieltolista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Estolistojen lähteet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -205,13 +205,17 @@ msgstr "DNS-sovellus"
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
@@ -219,15 +223,15 @@ msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 msgid "Date"
 msgstr "Päivä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Estä DNS:n salliminen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Estä DNS:n uudelleenkäynnistykset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -235,7 +239,7 @@ msgstr ""
 "Estä adblockin aiheuttamat DNS-sovelluksen uudelleenkäynnistykset autoload/"
 "inotify-funktioilla."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -271,11 +275,11 @@ msgstr "Lataustyökalu"
 msgid "E-Mail Notification"
 msgstr "Sähköposti-ilmoitus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Sähköposti-ilmoitusten määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Sähköpostiprofiili"
 
@@ -283,11 +287,11 @@ msgstr "Sähköpostiprofiili"
 msgid "E-Mail Receiver Address"
 msgstr "Sähköposti: vastaanottajan osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Sähköposti: lähettäjän osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Sähköposti: otsikko"
 
@@ -335,14 +339,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Nykyiset työt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -357,11 +365,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Tyhjennä DNS-välimuisti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä."
 
@@ -375,6 +387,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -396,7 +412,7 @@ msgstr "Salli pääsy Adblock-asetuksiin"
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -420,7 +436,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -468,7 +484,7 @@ msgstr "Ei vielä Adblock-lokeja!"
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -480,7 +496,7 @@ msgstr "Kysely"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -535,39 +551,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Raporttipalojen määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Raporttipalojen koko"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Raporttihakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Raportoitava sovitin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Raportoitavat portit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -601,18 +617,26 @@ msgstr ""
 msgid "Save"
 msgstr "Tallenna"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -625,11 +649,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Lähteet (koko, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -649,7 +673,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -661,7 +685,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -691,6 +715,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -715,7 +743,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -729,7 +757,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -746,8 +774,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -43,7 +43,7 @@ msgstr "Ajouter ce (sous-)domaine à la Liste noire locale."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout ce (sous-)domaine à la Liste blanche locale."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Liste additionnelle de blocage des Bannis"
 
@@ -68,11 +68,11 @@ msgstr "Paramètres d'e-mail avancés"
 msgid "Advanced Report Settings"
 msgstr "Paramètres de rapport avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Autoriser les IPs locales du client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -115,11 +115,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Liste noire ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Bloquer les IPs du client local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -154,7 +154,7 @@ msgstr "Demande à la liste de blocage..."
 msgid "Blocklist Sources"
 msgstr "Sources de la liste de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Catégories"
 
@@ -222,13 +222,17 @@ msgstr "Backend du DNS"
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Rapport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
@@ -236,15 +240,15 @@ msgstr "Délai de redémarrage DNS"
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -252,7 +256,7 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par AdBlock pour les backends DNS "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Désactiver les Listes blanches DNS séléctives (RPZ-PASSTHRU)."
 
@@ -288,11 +292,11 @@ msgstr "Télécharger l'utilitaire"
 msgid "E-Mail Notification"
 msgstr "Notification par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-mail du profil"
 
@@ -300,11 +304,11 @@ msgstr "E-mail du profil"
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Adresse e-mail de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Objet de l'e-mail"
 
@@ -356,11 +360,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -368,6 +372,10 @@ msgstr ""
 "Domaine externe pour vérifier la réussite du redémarrage du backend DNS. "
 "Remarque : Pour désactiver cette vérification, réglez cette option sur \"Faux"
 "\"."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -381,11 +389,15 @@ msgstr "Ports de pare-feu qui doivent être forcés localement."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zones sources du pare-feu qui doivent être forcées localement."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
@@ -400,6 +412,10 @@ msgstr "Ports forcés"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zones forcées"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -424,7 +440,7 @@ msgstr "Donner tout accès à l'application LuCI adblock"
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
@@ -448,7 +464,7 @@ msgstr "Limitez SafeSearch à certains fournisseurs."
 msgid "Line number to remove"
 msgstr "Numéro de la ligne à supprimer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
@@ -504,7 +520,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -518,7 +534,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -583,39 +599,39 @@ msgstr "Recharger"
 msgid "Remove an existing job"
 msgstr "Supprimer un travail existant"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Répertoire des rapports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Interface des rapports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -649,6 +665,10 @@ msgstr "Outils de travail"
 msgid "Save"
 msgstr "Enregistrer"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -657,7 +677,7 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
@@ -666,6 +686,10 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Configurer un nouveau travail AdBlock"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -679,11 +703,11 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
@@ -703,7 +727,7 @@ msgstr "Statut / Version"
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "Répertoire cible des rapports DNS."
 
@@ -716,7 +740,7 @@ msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
@@ -747,6 +771,10 @@ msgstr "La répartition des minutes (req., plage : 0-59)"
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "La sortie syslog, pré-filtrée pour les messages liés à adblock uniquement."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -784,7 +812,7 @@ msgstr ""
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -800,7 +828,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
@@ -817,8 +845,8 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Variantes"
 

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -68,11 +68,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -159,8 +159,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "ביטול"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -201,13 +201,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -215,21 +219,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -265,11 +269,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -277,11 +281,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -329,14 +333,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -351,11 +359,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -369,6 +381,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -390,7 +406,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -414,7 +430,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -462,7 +478,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -474,7 +490,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -529,39 +545,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -595,18 +611,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -619,11 +643,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -643,7 +667,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -655,7 +679,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -685,6 +709,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -709,7 +737,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -723,7 +751,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -740,8 +768,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -61,11 +61,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -101,11 +101,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -152,8 +152,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -194,13 +194,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -208,21 +212,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -258,11 +262,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -270,11 +274,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -322,14 +326,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -344,11 +352,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -362,6 +374,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -383,7 +399,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -407,7 +423,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -455,7 +471,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -467,7 +483,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -522,39 +538,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -588,18 +604,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -612,11 +636,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -636,7 +660,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -648,7 +672,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -678,6 +702,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -702,7 +730,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -716,7 +744,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -733,8 +761,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -69,11 +69,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -145,7 +145,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -160,8 +160,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -202,13 +202,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -216,21 +220,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -266,11 +270,11 @@ msgstr "Letöltési segédprogram"
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -278,11 +282,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -330,14 +334,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -352,11 +360,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -370,6 +382,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -391,7 +407,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -415,7 +431,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -464,7 +480,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -476,7 +492,7 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -531,39 +547,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -597,18 +613,26 @@ msgstr ""
 msgid "Save"
 msgstr "Mentés"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -621,11 +645,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -645,7 +669,7 @@ msgstr ""
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -657,7 +681,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -689,6 +713,10 @@ msgstr ""
 "A rendszernapló kimenete, előre szűrve csak a reklámblokkolóhoz kapcsolódó "
 "üzenetekhez."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -713,7 +741,7 @@ msgstr ""
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -727,7 +755,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -744,8 +772,8 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -46,7 +46,7 @@ msgstr "Aggiungi questo (sotto)dominio alla tua lista nera locale."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Aggiungi questo (sotto)dominio alla tua lista bianca locale."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -70,11 +70,11 @@ msgstr "Impostazioni E-Mail avanzate"
 msgid "Advanced Report Settings"
 msgstr "Impostazioni avanzate dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Consenti IP dei client locali"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -117,11 +117,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Blocca client IP locali"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -156,7 +156,7 @@ msgstr "Cerca lista di blocco..."
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -171,8 +171,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annulla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Categorie"
 
@@ -219,13 +219,17 @@ msgstr "Backend DNS"
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Report del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Tempo di riavvio del DNS"
 
@@ -233,21 +237,21 @@ msgstr "Tempo di riavvio del DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Disabilita Consenti DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Disabilita riavvio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Disabilita whitelist DNS selettiva (RPZ-PASSTHRU)."
 
@@ -283,11 +287,11 @@ msgstr "Utilità di download"
 msgid "E-Mail Notification"
 msgstr "Notifica e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Conteggio notifiche e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Profilo e-mail"
 
@@ -295,11 +299,11 @@ msgstr "Profilo e-mail"
 msgid "E-Mail Receiver Address"
 msgstr "Indirizzo e-mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Indirizzo e-mail mittente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Oggetto e-mail"
 
@@ -349,14 +353,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Processi esistenti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Dominio DNS di lookup esterno"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -371,11 +379,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -389,6 +401,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -410,7 +426,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -434,7 +450,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -483,7 +499,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -495,7 +511,7 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -551,39 +567,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -617,18 +633,26 @@ msgstr ""
 msgid "Save"
 msgstr "Salva"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -641,11 +665,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -665,7 +689,7 @@ msgstr ""
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -677,7 +701,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -708,6 +732,10 @@ msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "L'output di syslog, pre-filtrato solo per i messaggi relativi ad adblock."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -732,7 +760,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -746,7 +774,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -763,8 +791,8 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -46,7 +46,7 @@ msgstr "この(サブ)ドメインをローカルのブラックリストに追�
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "この(サブ)ドメインをローカルのホワイトリストに追加します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "追加のJailブロックリスト"
 
@@ -70,11 +70,11 @@ msgstr "Eメールの詳細設定"
 msgid "Advanced Report Settings"
 msgstr "リポートの詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "ブラックリスト..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -149,7 +149,7 @@ msgstr "ブロックリストのクエリ..."
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -215,13 +215,17 @@ msgstr "DNSバックエンド"
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNSレポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS再起動タイムアウト"
 
@@ -229,15 +233,15 @@ msgstr "DNS再起動タイムアウト"
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "DNS許可を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "DNS再起動を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -245,7 +249,7 @@ msgstr ""
 "autoload/inotify機能を使用してDNSバックエンドのadblockの再起動トリガーを無効"
 "にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -281,11 +285,11 @@ msgstr "ダウンロードユーティリティ"
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Eメール通知数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
@@ -293,11 +297,11 @@ msgstr "Eメールプロファイル"
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -347,17 +351,21 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "既存のジョブ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "外部DNSルックアップドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "DNSバックエンドが正常に再起動したかチェックする外部ドメイン。注意: このチェッ"
 "クを無効にするにはオプションを無効に設定してください。"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -371,11 +379,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "adblockが正常に動くようにするため、事前にDNSキャッシュをクリアします。"
 
@@ -389,6 +401,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -413,7 +429,7 @@ msgstr "LuCIアプリのadblockへのアクセスを許可"
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Jailディレクトリ"
 
@@ -437,7 +453,7 @@ msgstr "セーフサーチを特定のプロバイダに制限します。"
 msgid "Line number to remove"
 msgstr "削除する行番号"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdumpが使用する利用可能なネットワークデバイス一覧です。"
 
@@ -489,7 +505,7 @@ msgstr "まだadblolck関連のログがありません！"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp'をadblock通知Eメールに使用するプロファイル。"
 
@@ -501,7 +517,7 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "特定のドメインのアクティブなブロックリストとバックアップを検索します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -561,39 +577,39 @@ msgstr "リロード"
 msgid "Remove an existing job"
 msgstr "既存のジョブを削除"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "レポートポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "tcpdumpによって使用されるレポートチャンク数。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "tcpdumpがメガバイト単位で使用するレポートチャンクサイズ。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -627,6 +643,10 @@ msgstr "実行ユーティリティー"
 msgid "Save"
 msgstr "保存"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -635,12 +655,16 @@ msgstr ""
 "adblock関連の通知Eメールを送信します。注意: これは追加の'msmtp'パッケージのイ"
 "ンストールが必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "adblockの通知Eメール送信者アドレス。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -655,11 +679,11 @@ msgstr ""
 "ダウンロード処理(並べ替え、統合など)のダウンロードキューのサイズを並列で指定"
 "します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "ソース(サイズ、フォーカス)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdumpが使用するポートの、スペースで区切られたリスト。"
 
@@ -679,7 +703,7 @@ msgstr "ステータス / バージョン"
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -691,7 +715,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "生成されたjailブロックリスト'adb_list.jail'のターゲットディレクトリです。"
@@ -721,6 +745,10 @@ msgstr "分(オプション、0-59の値)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js:28
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "Adblock に関連するメッセージのみが抽出された、システムログ出力です。"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -752,7 +780,7 @@ msgstr ""
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "DNSバックエンドの再起動が成功するまでのタイムアウト。"
 
@@ -768,7 +796,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "上位10項目"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblockの通知Eメールのトピック。"
 
@@ -785,8 +813,8 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -43,7 +43,7 @@ msgstr "이 (서브)도메인을 로컬 블랙리스트에 추가."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "이 (서브)도메인을 로컬 화이트리스트에 추가."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "추가적인 Jail 블록리스트"
 
@@ -67,11 +67,11 @@ msgstr "고급 이메일 설정"
 msgid "Advanced Report Settings"
 msgstr "고급 리포트 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "블랙리스트..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -147,7 +147,7 @@ msgstr "블록리스트 등록..."
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -162,8 +162,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "취소"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -204,13 +204,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -218,21 +222,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -268,11 +272,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -280,11 +284,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -332,14 +336,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -354,11 +362,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -372,6 +384,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -393,7 +409,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -417,7 +433,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -465,7 +481,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -477,7 +493,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -532,39 +548,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -598,18 +614,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -622,11 +646,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -646,7 +670,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -658,7 +682,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -688,6 +712,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -712,7 +740,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -726,7 +754,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -743,8 +771,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -67,11 +67,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -158,8 +158,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -200,13 +200,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -214,21 +218,21 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -264,11 +268,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -276,11 +280,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -328,14 +332,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -350,11 +358,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -368,6 +380,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -389,7 +405,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -413,7 +429,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -461,7 +477,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -473,7 +489,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -528,39 +544,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -594,18 +610,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -618,11 +642,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -642,7 +666,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -654,7 +678,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -684,6 +708,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -708,7 +736,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -722,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -739,8 +767,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -43,7 +43,7 @@ msgstr "Legg til dette (under-)domenet til i din lokale svarteliste."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Legg til dette (under-)domenet til i din lokale hvitliste."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligere fengselssvarteliste"
 
@@ -69,11 +69,11 @@ msgstr "Avanserte e-postinnstillinger"
 msgid "Advanced Report Settings"
 msgstr "Avanserte rapporteringsinnstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Svartelist …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -148,7 +148,7 @@ msgstr "Blokkeringslistespørring …"
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Kategorier"
 
@@ -205,13 +205,17 @@ msgstr "DNS-bakende"
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS-omstartstidsavbrudd"
 
@@ -219,21 +223,21 @@ msgstr "DNS-omstartstidsavbrudd"
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Skru av DNS-tillatelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Skru av DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -269,11 +273,11 @@ msgstr "Nedlastingsverktøy"
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "E-postmerknadsantall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
@@ -281,11 +285,11 @@ msgstr "E-postprofil"
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -334,14 +338,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Eksisterende jobb(er)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Eksternt DNS-oppslagsdomene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -356,11 +364,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -375,6 +387,10 @@ msgstr "Påtvingte porter"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Påtvingte soner"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -395,7 +411,7 @@ msgstr "Innvilg tilgang til LuCI-programreklameblokkering"
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Fengselsmappe"
 
@@ -419,7 +435,7 @@ msgstr "Begrens SafeSearch til gitte tilbydere."
 msgid "Line number to remove"
 msgstr "Linjenummer å fjerne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste over tilgjengelige nettverksenheter brukt av tcpdump."
 
@@ -467,7 +483,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -479,7 +495,7 @@ msgstr "Spørring"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -534,39 +550,39 @@ msgstr "Last inn igjen"
 msgid "Remove an existing job"
 msgstr "Fjern en eksisterende jobb"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Rapportgrensesnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Rapportporter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -604,18 +620,26 @@ msgstr "Kjøringsverktøy"
 msgid "Save"
 msgstr "Lagre"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -628,11 +652,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Kilder (størrelse, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Mellomromsinndelt liste over porter brukt av tcpdump."
 
@@ -653,7 +677,7 @@ msgstr "Status/versjon"
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -665,7 +689,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -695,6 +719,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -719,7 +747,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tid"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -733,7 +761,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Topp 10-statistikk"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -750,8 +778,8 @@ msgstr "Utløserforsinkelse"
 msgid "Unable to save changes: %s"
 msgstr "Kunne ikke lagre endringer: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Varianter"
 

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -44,7 +44,7 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista blokująca"
 
@@ -70,11 +70,11 @@ msgstr "Zaawansowane ustawienia e-mail"
 msgid "Advanced Report Settings"
 msgstr "Ustawienia raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Zezwalaj na adresy IP klientów lokalnych"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -117,11 +117,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Czarna lista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Blokuj adresy IP klientów lokalnych"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -156,7 +156,7 @@ msgstr "Zapytanie..."
 msgid "Blocklist Sources"
 msgstr "Źródła list"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -175,8 +175,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Kategorie"
 
@@ -223,13 +223,17 @@ msgstr "Zaplecze DNS"
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
@@ -237,15 +241,15 @@ msgstr "Limit czasu restartu DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -253,7 +257,7 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Wyłącz selektywne białe listy DNS (RPZ-PASSTHRU)."
 
@@ -289,11 +293,11 @@ msgstr "Narzędzie pobierania"
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
@@ -301,11 +305,11 @@ msgstr "Profil e-mail"
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -356,11 +360,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -368,6 +372,10 @@ msgstr ""
 "Zewnętrzna domena do sprawdzania, czy restart zaplecza DNS zakończył się "
 "sukcesem. Uwaga: Aby wyłączyć to zaznaczenie, należy ustawić opcję na "
 "'false'."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -381,11 +389,15 @@ msgstr "Porty zapory, które powinny być wymuszane lokalnie."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Strefy źródłowe zapory, które powinny być wymuszane lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
@@ -400,6 +412,10 @@ msgstr "Wymuszone porty"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Strefy wymuszone"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -423,7 +439,7 @@ msgstr "Udziel dostępu LuCI do aplikacji adblock"
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
@@ -447,7 +463,7 @@ msgstr "Limit SafeSearch dla certyfikowanych dostawców."
 msgid "Line number to remove"
 msgstr "Numer wiersza do usunięcia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
@@ -501,7 +517,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie e-mail."
 
@@ -515,7 +531,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -576,39 +592,39 @@ msgstr "Przeładuj"
 msgid "Remove an existing job"
 msgstr "Usuń istniejące zadanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -642,6 +658,10 @@ msgstr "Uruchomione narzędzia"
 msgid "Save"
 msgstr "Zapisz"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -650,13 +670,17 @@ msgstr ""
 "Wysyłaj powiadomienia e-mail związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień e-mailowych adblocka."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Ustaw nowe zadanie adblocka"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -670,11 +694,11 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
@@ -694,7 +718,7 @@ msgstr "Status/Wersja"
 msgid "Suspend"
 msgstr "Wstrzymaj"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "Katalog docelowy dla plików raportów związanych z DNS."
 
@@ -707,7 +731,7 @@ msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
@@ -739,6 +763,10 @@ msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "Dane wyjściowe dziennika systemowego, wstępnie przefiltrowane dla informacji "
 "związanych z adblockiem."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -773,7 +801,7 @@ msgstr ""
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -789,7 +817,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień e-mail adblocka."
 
@@ -806,8 +834,8 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Warianty"
 

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -43,7 +43,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Priosional"
 
@@ -69,11 +69,11 @@ msgstr "Configurações avançadas de E-Mail"
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Permitir os IPs dos clientes locais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -117,11 +117,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Bloquear IPs de clientes locais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -156,7 +156,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -175,8 +175,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Categorias"
 
@@ -223,13 +223,17 @@ msgstr "Infraestrutura do DNS"
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -237,15 +241,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -253,7 +257,7 @@ msgstr ""
 "Desativar o adblock que causar a reinicialização das funções autoload/"
 "inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desativar a lista branca de DNS (RPZ-PASSTHRU)."
 
@@ -289,11 +293,11 @@ msgstr "Ferramenta para Descarregar"
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
@@ -301,11 +305,11 @@ msgstr "Perfil de e-mail"
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -357,11 +361,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -369,6 +373,10 @@ msgstr ""
 "Domínio externo para verificar se houve uma reinicialização bem sucedida da "
 "infraestrutura do DNS. Nota: defina como 'falsa' para desativar esta "
 "verificação."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -382,11 +390,15 @@ msgstr "Portas da firewall que devem ser localmente forçadas."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas fonte da firewall que devem ser localmente forçadas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também limpar o Cache do DNS antes do adblock."
 
@@ -401,6 +413,10 @@ msgstr "Portas forçadas"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas forçadas"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -425,7 +441,7 @@ msgstr "Conceder acesso à app LuCI adblock"
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -449,7 +465,7 @@ msgstr "Limite o SafeSearch a determinados provedores."
 msgid "Line number to remove"
 msgstr "Número da linha a remover"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de aparelhos da rede disponíveis que foram usados pelo tcpdump."
 
@@ -505,7 +521,7 @@ msgstr "Ainda não há registos relacionados ao adblock!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil dos e-mails de notificação do adblock utilizado por 'msmtp'."
 
@@ -519,7 +535,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -581,39 +597,39 @@ msgstr "Recarregar"
 msgid "Remove an existing job"
 msgstr "Remover uma tarefa existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -647,6 +663,10 @@ msgstr "Executar Utilitários"
 msgid "Save"
 msgstr "Guardar"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -655,13 +675,17 @@ msgstr ""
 "Envie e-mails de notificação relacionados ao adblock. Note que: a instalação "
 "adicional do pacote 'msmtp' é necessária."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Endereço E-Mail do remetente para as notificações do adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Definir uma nova tarefa de adblock"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -675,11 +699,11 @@ msgstr ""
 "Tamanho da fila de descarregamento para o processamento de descarregamento "
 "(incl. classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
@@ -699,7 +723,7 @@ msgstr "Condição geral / versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "Diretório de destino para ficheiros de relatório relacionados ao DNS."
 
@@ -712,7 +736,7 @@ msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -746,6 +770,10 @@ msgstr ""
 "A saída do syslog, pré-filtrada somente para mensagens relacionadas ao "
 "adblock."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -778,7 +806,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -794,7 +822,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos e-mails que serão usados nas notificações do adblock."
@@ -812,8 +840,8 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr "Impossível gravar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Variantes"
 

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -46,7 +46,7 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
@@ -72,11 +72,11 @@ msgstr "Configurações Avançadas do E-Mail"
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Permita os IPs dos clientes locais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -120,11 +120,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Bloqueie os IPs dos clientes locais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -159,7 +159,7 @@ msgstr "Pesquisando a Lista de Bloqueio..."
 msgid "Blocklist Sources"
 msgstr "Fontes das listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -178,8 +178,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Categorias"
 
@@ -226,13 +226,17 @@ msgstr "Infraestrutura do DNS"
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -240,15 +244,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -256,7 +260,7 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desative a lista branca do DNS (RPZ-PASSTHRU)."
 
@@ -292,11 +296,11 @@ msgstr "Ferramenta para Baixar"
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
@@ -304,11 +308,11 @@ msgstr "E-Mail do Perfil"
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -360,11 +364,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -372,6 +376,10 @@ msgstr ""
 "Domínio externo para verificar se houve uma reinicialização bem sucedida da "
 "infraestrutura do DNS. Nota: Defina como 'falsa' para desativar esta "
 "verificação."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -385,11 +393,15 @@ msgstr "As portas do firewall que devem ser impostas localmente."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origem do firewall que devem ser imposta localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
@@ -404,6 +416,10 @@ msgstr "Portas Impostas"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas Impostas"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -428,7 +444,7 @@ msgstr "Conceda acesso ao aplicativo LuCI adblock"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -452,7 +468,7 @@ msgstr "Limite o SafeSearch a determinados fornecedores."
 msgid "Line number to remove"
 msgstr "O número da linha para remover"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
@@ -507,7 +523,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -523,7 +539,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -588,39 +604,39 @@ msgstr "Recarregar"
 msgid "Remove an existing job"
 msgstr "Exclua uma tarefa já existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -654,6 +670,10 @@ msgstr "Executar Utilitários"
 msgid "Save"
 msgstr "Salvar"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -662,7 +682,7 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -670,6 +690,10 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Defina uma nova tarefa ao adblock"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -683,11 +707,11 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
@@ -707,7 +731,7 @@ msgstr "Condição Geral / Versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 "Diretório de destino dos relatórios para os arquivos relacionados ao DNS."
@@ -720,7 +744,7 @@ msgstr "O diretório de destino para os backups da lista de bloqueio."
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -752,6 +776,10 @@ msgstr "A parte dos minutos (obg., intervalo: 0-59)"
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "Saída do syslog, previamente filtrada para mensagens relacionadas ao adblock."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -787,7 +815,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -803,7 +831,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
@@ -822,8 +850,8 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Variantes"
 

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -44,7 +44,7 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -70,11 +70,11 @@ msgstr "Setări Avansate E-Mail"
 msgid "Advanced Report Settings"
 msgstr "Setări Avansate Raport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -114,11 +114,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista de Interzise..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -150,7 +150,7 @@ msgstr "Interogare Lista de Blocare..."
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -169,8 +169,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Renunțare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -217,13 +217,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "Director DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
@@ -231,15 +235,15 @@ msgstr "Timp Repornire DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -247,7 +251,7 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -283,11 +287,11 @@ msgstr "Utilitar descărcare"
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
@@ -295,11 +299,11 @@ msgstr "Profil E-Mail"
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -350,11 +354,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -362,6 +366,10 @@ msgstr ""
 "Domeniu extern pentru a verifica dacă a fost repornit cu succes un DNS. Vă "
 "rugăm să rețineți: pentru a dezactiva această verificare, setați această "
 "opțiune pe „falsă”."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -375,11 +383,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
@@ -393,6 +405,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -418,7 +434,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
@@ -442,7 +458,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
@@ -495,7 +511,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -509,7 +525,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -569,39 +585,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -635,18 +651,26 @@ msgstr ""
 msgid "Save"
 msgstr "Salvează"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -659,11 +683,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -683,7 +707,7 @@ msgstr ""
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -695,7 +719,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -725,6 +749,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -749,7 +777,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -763,7 +791,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -780,8 +808,8 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -49,7 +49,7 @@ msgstr "Добавить этот (под-)домен в локальный чё
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить этот (под-)домен в локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный «тюремный» список блокировок"
 
@@ -73,11 +73,11 @@ msgstr "Расширенные настройки электронной поч�
 msgid "Advanced Report Settings"
 msgstr "Расширенные настройки отчётов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Разрешить локальные IP-адреса клиента"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 #, fuzzy
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
@@ -121,11 +121,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Чёрный список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Блокировать локальные IP-адреса клиента"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 #, fuzzy
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
@@ -161,7 +161,7 @@ msgstr "Поиск по чёрному списку..."
 msgid "Blocklist Sources"
 msgstr "Источники черного списка"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -180,8 +180,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмена"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Категории"
 
@@ -228,13 +228,17 @@ msgstr "Служба DNS"
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Отчёт DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Тайм-аут перезапуска DNS"
 
@@ -242,15 +246,15 @@ msgstr "Тайм-аут перезапуска DNS"
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Отключить пропуск DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -258,7 +262,7 @@ msgstr ""
 "Отключить перезапуски служб DNS с функциями автозагрузки/inotify, вызываемые "
 "Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 #, fuzzy
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Отключить выборочные белые списки DNS (RPZ-PASSTHRU)."
@@ -295,11 +299,11 @@ msgstr "Утилита для загрузки"
 msgid "E-Mail Notification"
 msgstr "Уведомление по электронной почте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
@@ -307,11 +311,11 @@ msgstr "Профиль электронной почты"
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -361,11 +365,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Существующие задания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Внешний домен DNS Lookup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -373,6 +377,10 @@ msgstr ""
 "Внешний домен для проверки успешной перезагрузки DNS-сервера. <br /> "
 "<i>Обратите внимание: чтобы отключить эту проверку, установите для этой "
 "опции значение «false».</i>"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -387,11 +395,15 @@ msgstr "Порты файерволла, перенаправляемые лок
 msgid "Firewall source zones that should be forced locally."
 msgstr "Зоны файерволла, перенаправляемые локально."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Дополнительная очистка кэша DNS до его обработки Adblock."
 
@@ -409,6 +421,10 @@ msgstr "Перенаправляемые порты"
 #, fuzzy
 msgid "Forced Zones"
 msgstr "Перенаправляемые зоны"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -432,7 +448,7 @@ msgstr "Предоставить доступ к приложению Adblock д
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Папка для «тюрьмы»"
 
@@ -458,7 +474,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr "Номер строки для удаления"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств, используемых tcpdump."
 
@@ -511,7 +527,7 @@ msgstr "Ещё нет журналов, связанных с Adblock!"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Профиль, используемый 'msmtp' для отправки почтовых уведомлений."
 
@@ -524,7 +540,7 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 "Поиск определенного домена в активных списках блокировок и резервных копиях."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 #, fuzzy
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
@@ -587,39 +603,39 @@ msgstr "Перезапустить"
 msgid "Remove an existing job"
 msgstr "Удалить существующее задание"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Папка для отчётов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Интерфейсы в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Порты в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Количество фрагментов отчёта, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Размер фрагментов отчёта, используемых tcpdump, в мегабайтах."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -654,6 +670,10 @@ msgstr "Рабочие утилиты"
 msgid "Save"
 msgstr "Сохранить"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -662,13 +682,17 @@ msgstr ""
 "Отправлять связанные с adblock уведомления на e-mail. Замечание: требуется "
 "установка дополнительного пакета \"msmtp\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mail адрес отправителя уведомлений Adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Задать новое задание adblock"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -682,12 +706,12 @@ msgstr ""
 "Размер очереди параллельной загрузки для обработки загрузки (вкл. "
 "сортировку, слияние и т. д.)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 #, fuzzy
 msgid "Sources (Size, Focus)"
 msgstr "Источники (Размер, Фокусировка)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов, используемых tcpdump."
 
@@ -707,7 +731,7 @@ msgstr "Статус / Версия"
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 #, fuzzy
 msgid "Target directory for DNS related report files."
 msgstr "Целевой каталог для файлов отчетов, связанных с DNS."
@@ -720,7 +744,7 @@ msgstr "Целевой каталог для резервного копиров
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Папка для «тюремного» списка блокировки 'adb_list.jail'."
 
@@ -751,6 +775,10 @@ msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "Вывод системного журнала, предварительно отфильтрованного только для показа "
 "сообщений, связанных с Adblock."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -786,7 +814,7 @@ msgstr ""
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска службы DNS."
 
@@ -800,7 +828,7 @@ msgstr "Чтобы списки были актуальны, настройте 
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема, используемая для отправки электронных писем."
 
@@ -817,8 +845,8 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 #, fuzzy
 msgid "Variants"
 msgstr "Варианты"

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -43,7 +43,7 @@ msgstr "Pridať túto (sub-) doménu medzi lokálne zakázané domény."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Pridať túto (sub-) doménu medzi lokálne povolené domény."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -70,11 +70,11 @@ msgstr "Pokročilé nastavenia e-mailu"
 msgid "Advanced Report Settings"
 msgstr "Pokročilé nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Zoznam zakázaných domén..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -163,8 +163,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -205,13 +205,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -219,21 +223,21 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -269,11 +273,11 @@ msgstr "Nástroj na sťahovanie"
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -281,11 +285,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -333,14 +337,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -355,11 +363,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -373,6 +385,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -394,7 +410,7 @@ msgstr ""
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -418,7 +434,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -466,7 +482,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -478,7 +494,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -533,39 +549,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -599,18 +615,26 @@ msgstr ""
 msgid "Save"
 msgstr "Uložiť"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -623,11 +647,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -647,7 +671,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -659,7 +683,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -689,6 +713,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -713,7 +741,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -727,7 +755,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -744,8 +772,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -43,7 +43,7 @@ msgstr "Lägg till denna (under-)domän till din lokala svartlista."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lägg till denna (under-)domän i din lokala vitlista."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligare arrest-blocklista"
 
@@ -69,11 +69,11 @@ msgstr "Avancerade e-post-inställingar"
 msgid "Advanced Report Settings"
 msgstr "Avancerade rapportinställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -113,11 +113,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Svartlista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -149,7 +149,7 @@ msgstr "Blockeringslistsfråga..."
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -215,13 +215,17 @@ msgstr "DNS-bakände"
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "Tidsgräns för DNS-omstart"
 
@@ -229,15 +233,15 @@ msgstr "Tidsgräns för DNS-omstart"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "Inaktivera DNS-tillåtelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "Inaktivera DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -245,7 +249,7 @@ msgstr ""
 "Inaktivera annonsblockeringsstyrda omstarter av DNS-bakändar med autoload/"
 "inotify funktionalitet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -281,11 +285,11 @@ msgstr "Ladda ner verktyget"
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "Antal E-postaviseringar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
@@ -293,11 +297,11 @@ msgstr "E-postprofil"
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
@@ -345,17 +349,21 @@ msgstr "Påtvingar SafeSearch på Google, Bing, DuckDuckGo, Yandex och Pixbay."
 msgid "Existing job(s)"
 msgstr "Befintliga jobb"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Extern DNS-uppslagsdomän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "Extern domän för att verifiera en lyckad omstart av DNS-bakände. Notera: "
 "Inaktivera denna verifiering genom att välja alternativet 'false'."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -369,11 +377,15 @@ msgstr "Brandväggsportar som ska forceras lokalt."
 msgid "Firewall source zones that should be forced locally."
 msgstr "Brandväggskällzoner som ska forceras lokalt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spola också DNS-cachen innan annonsblockeringshantering."
 
@@ -388,6 +400,10 @@ msgstr "Forcerade portar"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Forcerade zoner"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -412,7 +428,7 @@ msgstr "Ge tillgång till LuCi-programmet annonsblockering"
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Arrestkatalog"
 
@@ -436,7 +452,7 @@ msgstr "Begränsa SafeSearch till vissa leverantörer."
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista med tillgängliga nätverksenheter använda av tcpdump."
 
@@ -489,7 +505,7 @@ msgstr "Inga annonsblockerinsrelaterade loggar ännu!"
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Profil som används av 'msmtp' för annonsblockeringsaviserinse-"
@@ -503,7 +519,7 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Fråga aktiva svartlistor och säkerhetskopior efter en given domän."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -565,39 +581,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Rapportera klimpantal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Rapportera klimpstorlek"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Rapportgränssnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Rapporthamnar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Rapportera klimpantal använt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Rapportera klimpstorlek som används av tcpdump i MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -631,18 +647,26 @@ msgstr "Kör verktyg"
 msgid "Save"
 msgstr "Spara"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -655,11 +679,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -679,7 +703,7 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -691,7 +715,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -721,6 +745,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -745,7 +773,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -759,7 +787,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -776,8 +804,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -58,11 +58,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -98,11 +98,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,8 +149,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -191,13 +191,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -205,21 +209,21 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -255,11 +259,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -267,11 +271,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -319,14 +323,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -341,11 +349,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -359,6 +371,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -380,7 +396,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -404,7 +420,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -452,7 +468,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -464,7 +480,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -519,39 +535,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -585,18 +601,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -609,11 +633,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -633,7 +657,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -645,7 +669,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -675,6 +699,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -699,7 +727,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -713,7 +741,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -730,8 +758,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -43,7 +43,7 @@ msgstr "Bu (alt-)alan adını yerel kara listenize ekleyin."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Bu (alt)alan adını yerel izin verilen listenize ekleyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "Ek \"Hapis\" Engelleme listesi"
 
@@ -68,11 +68,11 @@ msgstr "Gelişmiş E-Posta Ayarları"
 msgid "Advanced Report Settings"
 msgstr "Gelişmiş Rapor Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "Yerel İstemci IP'lerine İzin Ver"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -115,11 +115,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Kara liste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "Yerel İstemci IP'lerini Engelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -154,7 +154,7 @@ msgstr "Engelleme Listesi Sorgusu..."
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -173,8 +173,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "İptal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "Kategoriler"
 
@@ -222,13 +222,17 @@ msgstr "DNS Arka Uç"
 msgid "DNS Directory"
 msgstr "DNS Dizini"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS Raporu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 
@@ -236,15 +240,15 @@ msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 msgid "Date"
 msgstr "Tarih"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "DNS İzin Vermeyi Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "DNS Yeniden Başlatmalarını Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -252,7 +256,7 @@ msgstr ""
 "Adblock tarafından tetiklenen autoload/inotify fonksiyonları ile dns arka uç "
 "yeniden başlatmasını devre dışı bırakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Seçici DNS beyaz listeyi (RPZ-PASSTHRU) devre dışı bırakın."
 
@@ -288,11 +292,11 @@ msgstr "İndirme Aracı"
 msgid "E-Mail Notification"
 msgstr "E-Posta Bildirimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "E-Posta Bildirim Sayısı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "E-Posta Profili"
 
@@ -300,11 +304,11 @@ msgstr "E-Posta Profili"
 msgid "E-Mail Receiver Address"
 msgstr "E-Posta Alıcı Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "E-Posta Gönderen Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "E-Posta Konusu"
 
@@ -356,11 +360,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Mevcut iş(ler)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "Harici DNS Arama Alanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -368,6 +372,10 @@ msgstr ""
 "DNS arkaucunun başarılı şekilde yeniden başlatıldığını kontrol eden harici "
 "alan. Lütfen dikkat: Bu kontrolü devre dışı bırakmak için 'false' olarak "
 "ayarlayın."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -381,11 +389,15 @@ msgstr "Yerel olarak zorlanması gereken güvenlik duvarı bağlantı noktaları
 msgid "Firewall source zones that should be forced locally."
 msgstr "Yerel olarak zorunlu olması gereken güvenlik duvarı kaynak bölgeleri."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "DNS Önbelleğini Temizle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Adblock işleminden önce de DNS Önbelleğini temizle."
 
@@ -400,6 +412,10 @@ msgstr "Zorlanan Erişim Noktaları"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zorlanan Bölgeler"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -424,7 +440,7 @@ msgstr "LuCI uygulaması adblock'a izin verin"
 msgid "Information"
 msgstr "Bilgi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Kafes Dizini"
 
@@ -448,7 +464,7 @@ msgstr "Belirli sağlayıcılar için GüvenliArama'yı limitle."
 msgid "Line number to remove"
 msgstr "Kaldırılacak satırın numarası"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump tarafından kullanılan mevcut ağ aygıtlarının listesi."
 
@@ -504,7 +520,7 @@ msgstr "Henüz adblock ile ilgili kayıt yok!"
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Adblock bildirim e-postaları için 'msmtp' tarafından kullanılan profil."
@@ -519,7 +535,7 @@ msgstr ""
 "Belirli bir etki alanı için etkin engelleme listelerini ve yedeklemeleri "
 "sorgulayın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -581,39 +597,39 @@ msgstr "Yeniden yükle"
 msgid "Remove an existing job"
 msgstr "Mevcut bir işi kaldırın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "Yığın Sayısını Bildir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "Yığın Boyutunu Bildir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "Rapor Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "Rapor Arayüzü"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "Rapor Bağlantı Noktaları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "Tcpdump tarafından kullanılan yığın sayısını bildirin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Tcpdump tarafından kullanılan yığın boyutunu MByte cinsinden bildirin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -647,6 +663,10 @@ msgstr "Araçları Çalıştır"
 msgid "Save"
 msgstr "Kaydet"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -655,13 +675,17 @@ msgstr ""
 "Adblock ile ilgili bildirim e-postaları gönderin. Lütfen dikkat: bu, ek "
 "'msmtp' paket kurulumuna ihtiyaç duyar."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adblock bildirim e-postaları için gönderen adresi."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "Yeni bir reklam engelleme işi ayarlayın"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -675,11 +699,11 @@ msgstr ""
 "Paralel olarak indirme işlemi için indirme kuyruğunun boyutu (sıralama, "
 "birleştirme vb.) Dahil."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "Kaynaklar (Boyut, Odak)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 "Tcpdump tarafından kullanılan bağlantı noktalarının boşlukla ayrılmış "
@@ -701,7 +725,7 @@ msgstr "Durum / Sürüm"
 msgid "Suspend"
 msgstr "Askıya al"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "DNS ile ilgili rapor dosyaları için hedef dizin."
 
@@ -713,7 +737,7 @@ msgstr "Engelleme listesi yedeklemeleri için hedef dizin."
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Oluşturulan engelleme listesi 'adb_list.overall' için hedef dizin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Oluşturulan engelleme listesi 'adb_list.jail' için hedef dizin."
 
@@ -744,6 +768,10 @@ msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 "Yalnızca adblock ile ilgili mesajlar için önceden filtrelenmiş syslog "
 "çıktısı."
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -779,7 +807,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zaman"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Başarılı bir DNS arka uç yeniden başlatması için bekleme süresi."
 
@@ -795,7 +823,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "En İyi 10 İstatistik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock bildirim e-postaları için konu."
 
@@ -812,8 +840,8 @@ msgstr "Tetikleme Gecikmesi"
 msgid "Unable to save changes: %s"
 msgstr "Değişiklikler kaydedilemiyor: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "Varyantlar"
 

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -68,11 +68,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -159,8 +159,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -201,13 +201,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -215,21 +219,21 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -265,11 +269,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -277,11 +281,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -329,14 +333,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -351,11 +359,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -369,6 +381,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -390,7 +406,7 @@ msgstr ""
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -414,7 +430,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -462,7 +478,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -474,7 +490,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -529,39 +545,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -595,18 +611,26 @@ msgstr ""
 msgid "Save"
 msgstr "Зберегти"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -619,11 +643,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -643,7 +667,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -655,7 +679,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -685,6 +709,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -709,7 +737,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -723,7 +751,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -740,8 +768,8 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr ""
 
@@ -68,11 +68,11 @@ msgstr ""
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -144,7 +144,7 @@ msgstr ""
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -159,8 +159,8 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr ""
 
@@ -202,13 +202,17 @@ msgstr ""
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -216,21 +220,21 @@ msgstr ""
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -266,11 +270,11 @@ msgstr ""
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr ""
 
@@ -278,11 +282,11 @@ msgstr ""
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -330,14 +334,18 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
@@ -352,11 +360,15 @@ msgstr ""
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
@@ -370,6 +382,10 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
@@ -391,7 +407,7 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr ""
 
@@ -415,7 +431,7 @@ msgstr ""
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
@@ -463,7 +479,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -475,7 +491,7 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -530,39 +546,39 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -596,18 +612,26 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
@@ -620,11 +644,11 @@ msgid ""
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
@@ -644,7 +668,7 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr ""
 
@@ -656,7 +680,7 @@ msgstr ""
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -686,6 +710,10 @@ msgstr ""
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -710,7 +738,7 @@ msgstr ""
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -724,7 +752,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -741,8 +769,8 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -50,7 +50,7 @@ msgstr "添加此域名到本地黑名单。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "其它被屏蔽列表"
 
@@ -74,11 +74,11 @@ msgstr "高级设置 - 邮箱"
 msgid "Advanced Report Settings"
 msgstr "高级设置 - 报告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr "允许本地客户端 IP"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -116,11 +116,11 @@ msgstr "黑名单更改已保存。刷新您的广告拦截列表以使更改生
 msgid "Blacklist..."
 msgstr "黑名单..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr "拦截本地客户端IP"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -154,7 +154,7 @@ msgstr "黑名单查询..."
 msgid "Blocklist Sources"
 msgstr "阻止列表内容"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -171,8 +171,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "类别"
 
@@ -216,13 +216,17 @@ msgstr "DNS后端"
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS报告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
@@ -230,21 +234,21 @@ msgstr "DNS重新启动超时"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "禁用DNS允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁止广告拦截触发具有 自动加载/inotify 功能的 DNS 后端的重新启动。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "禁用选择性DNS白名单（RPZ-PASSTHRU）。"
 
@@ -280,11 +284,11 @@ msgstr "下载工具"
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
@@ -292,11 +296,11 @@ msgstr "电子邮件概要"
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -344,17 +348,21 @@ msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的Saf
 msgid "Existing job(s)"
 msgstr "现有任务"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "外部域，用于检查DNS后端是否成功重启。请注意：要禁用此检查，请将此选项设置为“ "
 "false”。"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -368,11 +376,15 @@ msgstr "本地应强制使用的防火墙端口。"
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地应强制使用的防火墙源域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "在处理广告过滤之前刷新 DNS 缓存。"
 
@@ -387,6 +399,10 @@ msgstr "强制端口"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "强制域"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -409,7 +425,7 @@ msgstr "授予访问 LuCI 应用 adblock 的权限"
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
@@ -433,7 +449,7 @@ msgstr "限定特定搜索引擎使用安全搜索。"
 msgid "Line number to remove"
 msgstr "要移除的行号"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
@@ -484,7 +500,7 @@ msgstr "尚无与广告拦截相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -496,7 +512,7 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -554,39 +570,39 @@ msgstr "重新加载"
 msgid "Remove an existing job"
 msgstr "移除一个现有任务"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "报告端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "报告 tcpdump 所使用的区块数量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "报告 tcpdump 所使用的区块大小 (以 MByte 显示)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -620,19 +636,27 @@ msgstr "运行工具"
 msgid "Save"
 msgstr "保存"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr "发送 AdBlock 相关的通知邮件。请留意：此功能需要安装 \"msmtp\"。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "AdBlock 通知邮件的发送地址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "设置一个新的广告拦截作业"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -644,11 +668,11 @@ msgid ""
 "etc.) in parallel."
 msgstr "并行下载处理 (分类、合并等) 的下载队列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "来源（大小，焦点）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump使用的端口列表，用空格分隔端口。"
 
@@ -668,7 +692,7 @@ msgstr "状态 / 版本"
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "DNS 相关报告文件的目标目录。"
 
@@ -680,7 +704,7 @@ msgstr "拦截列表备份的目标目录。"
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
@@ -710,6 +734,10 @@ msgstr "分钟（可选。取值范围：0-59）"
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "系统日志输出，仅针对 adblock 相关的消息进行了预筛选。"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
 "This is the local adblock blacklist to always-deny certain (sub) domains."
@@ -738,7 +766,7 @@ msgstr "此选项卡显示上次生成的 DNS 报告，按“刷新”按钮获�
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待成功的DNS后端重新启动的超时。"
 
@@ -752,7 +780,7 @@ msgstr "为了使您的广告过滤列表保持最新，您应该为这些列表
 msgid "Top 10 Statistics"
 msgstr "前 10 统计数据"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "广告拦截通知邮件的主题。"
 
@@ -769,8 +797,8 @@ msgstr "触发延时"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改：%s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "变种"
 

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -49,7 +49,7 @@ msgstr "加入該（子）域名到您的本地黑名單。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "加入該（子）域名到您的本地白名單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid "Additional Jail Blocklist"
 msgstr "附加 Jail 封鎖清單"
 
@@ -73,11 +73,11 @@ msgstr "進階電郵設定"
 msgid "Advanced Report Settings"
 msgstr "進階報告設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Allow Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -114,11 +114,11 @@ msgstr "黑名單變更已儲存；請重新整理您的 Adblock 清單來使變
 msgid "Blacklist..."
 msgstr "黑名單…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid "Block Local Client IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:466
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -150,7 +150,7 @@ msgstr "黑名單查詢…"
 msgid "Blocklist Sources"
 msgstr "封鎖清單來源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:468
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -167,8 +167,8 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:575
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:590
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:585
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:600
 msgid "Categories"
 msgstr "類別"
 
@@ -213,13 +213,17 @@ msgstr "DNS 後端"
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "DNS Instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS 報告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "DNS Restart Timeout"
 msgstr "DNS 重新啟動逾時值"
 
@@ -227,21 +231,21 @@ msgstr "DNS 重新啟動逾時值"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable DNS Allow"
 msgstr "停用 DNS 解析修改"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid "Disable DNS Restarts"
 msgstr "停用 DNS 重新啟動"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:477
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:487
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "停用 Adblock 觸發具有「自動載入／inotify 」功能的 DNS 後端重新啟動。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:453
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
@@ -277,11 +281,11 @@ msgstr "下載工具"
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid "E-Mail Notification Count"
 msgstr "電郵通知數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "E-Mail Profile"
 msgstr "電郵設定檔"
 
@@ -289,11 +293,11 @@ msgstr "電郵設定檔"
 msgid "E-Mail Receiver Address"
 msgstr "電郵收件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "E-Mail Sender Address"
 msgstr "電郵寄件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "E-Mail Topic"
 msgstr "電郵主旨"
 
@@ -343,17 +347,21 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "現存工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid "External DNS Lookup Domain"
 msgstr "供 DNS 查詢的外部域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
 msgstr ""
 "使用外部網域來檢查「DNS 後端」是否成功重新啟動；請注意：要停用此檢查，請輸入 "
 "\"false\"。"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
+msgid "Fifth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
 msgid "Filter criteria like date, domain or client (optional)"
@@ -367,11 +375,15 @@ msgstr "本地應被強制重新導向的防火牆通訊埠號。"
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地應被強制重新導向的防火牆來源區域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+msgid "First instance (default)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush DNS Cache"
 msgstr "清除 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:460
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "在 Adblock 行程啟動前也要清除 DNS 快取。"
 
@@ -386,6 +398,10 @@ msgstr "強制埠號"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "強制區域"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+msgid "Fourth instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
@@ -408,7 +424,7 @@ msgstr "授予 luci-app-adblock 擁有 UCI 存取的權限"
 msgid "Information"
 msgstr "資訊"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Jail Directory"
 msgstr "Jail 檔案目錄"
 
@@ -432,7 +448,7 @@ msgstr "啟用限制性安全搜尋，以限制給定搜尋引擎的搜尋範圍
 msgid "Line number to remove"
 msgstr "要移除的行號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "List of available network devices used by tcpdump."
 msgstr "用於 tcpdump 的可用網路裝置清單。"
 
@@ -483,7 +499,7 @@ msgstr "尚無與 Adblock 相關的日誌！"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:525
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:535
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "\"msmtp\" 使用的設定檔，用於 Adblock 寄送通知電子郵件。"
 
@@ -495,7 +511,7 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查詢「特定網域」的活躍封鎖清單和備份。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:529
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:539
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -556,39 +572,39 @@ msgstr "重新載入"
 msgid "Remove an existing job"
 msgstr "移除一個現存工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report Chunk Count"
 msgstr "報告區塊數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:498
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Report Ports"
 msgstr "報告埠號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
 msgid "Report chunk count used by tcpdump."
 msgstr "報告 tcpdump 使用的區塊數量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:512
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "報告 tcpdump 使用的區塊大小（單位：MB）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve IPs"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:511
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -622,6 +638,10 @@ msgstr "執行工具"
 msgid "Save"
 msgstr "儲存"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
+msgid "Second instance"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
@@ -629,13 +649,17 @@ msgid ""
 msgstr ""
 "寄送與 Adblock 相關的通知電子郵件；請注意：這需要安裝 \"msmtp\" 附加套件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的寄件人位址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
 msgid "Set a new adblock job"
 msgstr "設定一個新的廣告攔截工作"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+msgid "Set the dns backend instance used by adblock."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
@@ -647,11 +671,11 @@ msgid ""
 "etc.) in parallel."
 msgstr "平行下載處理（包含排序、合併等）的下載佇列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:561
 msgid "Sources (Size, Focus)"
 msgstr "來源（大小、聚焦的類別）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:507
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump 使用的通訊埠號（以空格分隔）。"
 
@@ -671,7 +695,7 @@ msgstr "狀態／版本"
 msgid "Suspend"
 msgstr "掛起"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:503
 msgid "Target directory for DNS related report files."
 msgstr "DNS 相關報告檔案的目標目錄。"
 
@@ -683,7 +707,7 @@ msgstr "攔截清單備份的目標目錄。"
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "產生封鎖清單 \"adb_list.overall\" 的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "產生 Jail 封鎖清單 \"adb_list.jail\" 的目標目錄。"
 
@@ -712,6 +736,10 @@ msgstr "分鐘部分（取值範圍：0-59，必需）"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/logread.js:28
 msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr "系統日誌輸出（預先篩選出只與 Adblock 相關的訊息）。"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
+msgid "Third instance"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js:23
 msgid ""
@@ -743,7 +771,7 @@ msgstr "此頁籤顯示上次產生的 DNS 報告，按「更新」按鈕取得�
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:450
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待 DNS 後端成功重新啟動的逾時值。"
 
@@ -757,7 +785,7 @@ msgstr "要保持最新的 Adblock 清單，您應該設定這些清單的自動
 msgid "Top 10 Statistics"
 msgstr "前 10 統計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:531
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的主旨。"
 
@@ -774,8 +802,8 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr "無法儲存變更（訊息：%s）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:605
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:621
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:615
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:631
 msgid "Variants"
 msgstr "變體"
 


### PR DESCRIPTION
* expose the 'adb_dnsinstance' option to LuCI under
  Advanced DNS Settings (only relevant for dnsmasq)
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>