### PR TITLE
Openwrt 21.02 pr更新 2021.7.14

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -219,16 +219,13 @@ return view.extend({
 		o.modalonly = true;
 		o.value('shadow', _('Use UNIX password in /etc/shadow'));
 		o.value('crypted', _('Use encrypted password hash'));
-		o.value('plain', _('Use plain password'));
 		o.cfgvalue = function(section_id) {
 			var value = uci.get('rpcd', section_id, 'password') || '';
 
 			if (value.substring(0, 3) == '$p$')
 				return 'shadow';
-			else if (value.substring(0, 3) == '$1$' || value == null)
-				return 'crypted';
 			else
-				return 'plain';
+				return 'crypted';
 		};
 		o.write = function() {};
 
@@ -249,7 +246,6 @@ return view.extend({
 		o.password = true;
 		o.rmempty = false;
 		o.depends('_variant', 'crypted');
-		o.depends('_variant', 'plain');
 		o.cfgvalue = function(section_id) {
 			var value = uci.get('rpcd', section_id, 'password') || '';
 			return (value.substring(0, 3) == '$p$') ? '' : value;


### PR DESCRIPTION
Upon reviewing the rpcd session support code, it turns out that account
definitions with plaintext password values are not supported, the password
value is treated as crypt() hash/salt in any case.

Ref: https://github.com/openwrt/luci/issues/5179
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit f74b06cb92e403fa281414d5a6bd57228858bfa7)